### PR TITLE
Support for LongArrayTag

### DIFF
--- a/src/BigEndianNBTStream.php
+++ b/src/BigEndianNBTStream.php
@@ -84,4 +84,14 @@ class BigEndianNBTStream extends NBTStream{
 		$this->putInt(count($array));
 		$this->put(pack("N*", ...$array));
 	}
+
+	public function getLongArray() : array{
+		$len = $this->getInt();
+		return array_values(unpack("J*", $this->get($len * 8)));
+	}
+
+	public function putLongArray(array $array) : void{
+		$this->putInt(count($array));
+		$this->put(pack("J*", ...$array));
+	}
 }

--- a/src/LittleEndianNBTStream.php
+++ b/src/LittleEndianNBTStream.php
@@ -84,4 +84,14 @@ class LittleEndianNBTStream extends NBTStream{
 		$this->putInt(count($array));
 		$this->put(pack("V*", ...$array));
 	}
+
+	public function getLongArray() : array{
+		$len = $this->getInt();
+		return array_values(unpack("P*", $this->get($len * 8)));
+	}
+
+	public function putLongArray(array $array) : void{
+		$this->putInt(count($array));
+		$this->put(pack("P*", ...$array));
+	}
 }

--- a/src/NBT.php
+++ b/src/NBT.php
@@ -53,6 +53,7 @@ abstract class NBT{
 	public const TAG_List = 9;
 	public const TAG_Compound = 10;
 	public const TAG_IntArray = 11;
+	public const TAG_LongArray = 12;
 
 	/**
 	 * @param int $type

--- a/src/NBT.php
+++ b/src/NBT.php
@@ -34,6 +34,7 @@ use pocketmine\nbt\tag\FloatTag;
 use pocketmine\nbt\tag\IntArrayTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\LongArrayTag;
 use pocketmine\nbt\tag\LongTag;
 use pocketmine\nbt\tag\NamedTag;
 use pocketmine\nbt\tag\ShortTag;
@@ -84,6 +85,8 @@ abstract class NBT{
 				return new CompoundTag();
 			case self::TAG_IntArray:
 				return new IntArrayTag();
+			case self::TAG_LongArray:
+				return new LongArrayTag();
 			default:
 				throw new \InvalidArgumentException("Unknown NBT tag type $type");
 		}

--- a/src/NBTStream.php
+++ b/src/NBTStream.php
@@ -209,6 +209,10 @@ abstract class NBTStream{
 
 	abstract public function putIntArray(array $array) : void;
 
+	abstract public function getLongArray() : array;
+
+	abstract public function putLongArray(array $array) : void;
+
 
 
 	public function getArray() : array{

--- a/src/NetworkLittleEndianNBTStream.php
+++ b/src/NetworkLittleEndianNBTStream.php
@@ -75,4 +75,21 @@ class NetworkLittleEndianNBTStream extends LittleEndianNBTStream{
 			$this->putInt($v); //varint
 		}
 	}
+
+	public function getLongArray() : array{
+		$len = $this->getInt(); //varint
+		$ret = [];
+		for($i = 0; $i < $len; ++$i){
+			$ret[] = $this->getLong(); //varlong
+		}
+
+		return $ret;
+	}
+
+	public function putLongArray(array $array) : void{
+		$this->putInt(count($array)); //varint
+		foreach($array as $v){
+			$this->putLong($v); //varlong
+		}
+	}
 }

--- a/src/tag/CompoundTag.php
+++ b/src/tag/CompoundTag.php
@@ -296,6 +296,17 @@ class CompoundTag extends NamedTag implements \ArrayAccess, \Iterator, \Countabl
 	}
 
 	/**
+	 * @param string     $name
+	 * @param int[]|null $default
+	 * @param bool       $badTagDefault
+	 *
+	 * @return int[]
+	 */
+	public function getLongArray(string $name, ?array $default = null, bool $badTagDefault = false) : array{
+		return $this->getTagValue($name, LongArrayTag::class, $default, $badTagDefault);
+	}
+
+	/**
 	 * Sets the value of the child tag at the specified offset, creating it if it does not exist. If the child tag
 	 * exists and the value is of the wrong type, an exception will be thrown.
 	 *
@@ -399,6 +410,14 @@ class CompoundTag extends NamedTag implements \ArrayAccess, \Iterator, \Countabl
 		$this->setTagValue($name, IntArrayTag::class, $value, $force);
 	}
 
+	/**
+	 * @param string $name
+	 * @param int[]  $value
+	 * @param bool   $force
+	 */
+	public function setLongArray(string $name, array $value, bool $force = false) : void{
+		$this->setTagValue($name, LongArrayTag::class, $value, $force);
+	}
 
 	/**
 	 * @param string $offset

--- a/src/tag/LongArrayTag.php
+++ b/src/tag/LongArrayTag.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\nbt\tag;
+
+use pocketmine\nbt\NBT;
+use pocketmine\nbt\NBTStream;
+
+class LongArrayTag extends NamedTag{
+	/** @var int[] */
+	protected $value = [];
+
+	/**
+	 * LongArrayTag constructor.
+	 *
+	 * @param string $name
+	 * @param int[]  $value
+	 */
+	public function __construct(string $name = "", array $value = []){
+		parent::__construct($name, $value);
+	}
+
+	public function getType() : int{
+		return NBT::TAG_LongArray;
+	}
+
+	public function read(NBTStream $nbt) : void{
+		$this->value = $nbt->getLongArray();
+	}
+
+	public function write(NBTStream $nbt) : void{
+		$nbt->putLongArray($this->value);
+	}
+
+	public function __toString(){
+		$str = get_class($this) . "{\n";
+		$str .= implode(", ", $this->value);
+		return $str . "}";
+	}
+
+	/**
+	 * @return int[]
+	 */
+	public function &getValue() : array{
+		return parent::getValue();
+	}
+
+	/**
+	 * @param int[] $value
+	 *
+	 * @throws \TypeError
+	 */
+	public function setValue($value) : void{
+		if(!is_array($value)){
+			throw new \TypeError("LongArrayTag value must be of type int[], " . gettype($value) . " given");
+		}
+		assert(count(array_filter($value, function($v){
+			return !is_int($v);
+		})) === 0);
+
+		parent::setValue($value);
+	}
+
+}


### PR DESCRIPTION
This is currently untested.

Additionally MCPE doesn't have TAG_LongArray yet, so it is possible they may botch up its addition and screw up the consistency. The `LittleEndianNBTStream` and `NetworkLittleEndianNBTStream` are the expected logic paths should the format remain consistent with PC.

Closes #35 .