### PR TITLE
Root tag may not be a Compound

### DIFF
--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -51,6 +51,9 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 */
 	private function readRoot(int $maxDepth) : TreeRoot{
 		$type = $this->readByte();
+		if($type === NBT::TAG_End){
+			throw new NbtDataException("Found TAG_End at the start of buffer");
+		}
 
 		$rootName = $this->readString();
 		return new TreeRoot(NBT::createTag($type, $this, new ReaderTracker($maxDepth)), $rootName);

--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
-use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\utils\Binary;
 use pocketmine\utils\BinaryDataException;
 use pocketmine\utils\BinaryStream;
@@ -52,12 +51,9 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 */
 	private function readRoot(int $maxDepth) : TreeRoot{
 		$type = $this->readByte();
-		if($type !== NBT::TAG_Compound){
-			throw new NbtDataException("Expected TAG_Compound at the start of buffer");
-		}
 
 		$rootName = $this->readString();
-		return new TreeRoot(CompoundTag::read($this, new ReaderTracker($maxDepth)), $rootName);
+		return new TreeRoot(NBT::createTag($type, $this, new ReaderTracker($maxDepth)), $rootName);
 	}
 
 	/**
@@ -85,7 +81,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	/**
-	 * Decodes a list of TAG_Compound into objects and returns them.
+	 * Decodes a list of NBT tags into objects and returns them.
 	 *
 	 * TODO: This is only necessary because we don't have a streams API worth mentioning. Get rid of this in the future.
 	 *
@@ -135,7 +131,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	private function writeRoot(TreeRoot $root) : void{
-		$this->writeByte(NBT::TAG_Compound);
+		$this->writeByte($root->getTag()->getType());
 		$this->writeString($root->getName());
 		$root->getTag()->write($this);
 	}

--- a/src/TreeRoot.php
+++ b/src/TreeRoot.php
@@ -23,28 +23,28 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
-use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\Tag;
 use function get_class;
 
 /**
- * This class wraps around the root CompoundTag for NBT files to avoid losing the name information.
+ * This class wraps around the root Tag for NBT files to avoid losing the name information.
  */
 class TreeRoot{
 
-	/** @var CompoundTag */
+	/** @var Tag */
 	private $root;
 	/** @var string */
 	private $name;
 
-	public function __construct(CompoundTag $root, string $name = ""){
+	public function __construct(Tag $root, string $name = ""){
 		$this->root = $root;
 		$this->name = $name;
 	}
 
 	/**
-	 * @return CompoundTag
+	 * @return Tag
 	 */
-	public function getTag() : CompoundTag{
+	public function getTag() : Tag{
 		return $this->root;
 	}
 


### PR DESCRIPTION
# Introduction
In the latest `Minecraft: Bedrock Edition` release, one can observe that TreeRoot may not be exactly a CompoundTag.(for example: you can see this in StartGamePacket...)

My PR corrects this situation, but not to the end: I suppose, in the PMMP you will have to do additional validators like `$treeRoot->getTag() instanceof CompoundTag` ...

# Relevant issues
* Fixes #52