### PR TITLE
First look at ext-encoding integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,16 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup PHP
-      uses: shivammathur/setup-php@2.31.1
+      uses: shivammathur/setup-php@2.35.4
       with:
         php-version: ${{ matrix.php }}
         ini-values: xdebug.max_nesting_level=3000
+        extensions: encoding-https://github.com/pmmp/ext-encoding@0.5.1
     - name: Cache Composer packages
       id: composer-cache
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         ini-values: xdebug.max_nesting_level=3000
-        extensions: encoding-https://github.com/pmmp/ext-encoding@0.5.1
+        extensions: encoding-pmmp/ext-encoding@1.0.0
 
     - name: Cache Composer packages
       id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "php-64bit": "*",
-        "pocketmine/binaryutils": "^0.2.0"
+        "ext-encoding": "~0.2.1"
     },
     "require-dev": {
         "phpstan/phpstan": "1.10.25",

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "PHP library for working with Named Binary Tags",
     "type": "library",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "php-64bit": "*",
-        "ext-encoding": "~0.4.0"
+        "ext-encoding": "~0.5.0"
     },
     "require-dev": {
         "phpstan/phpstan": "2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "require": {
         "php": "^8.1",
         "php-64bit": "*",
-        "pocketmine/binaryutils": "^0.2.0",
-        "ext-encoding": "~0.5.0"
+        "ext-encoding": "~1.0.0"
     },
     "require-dev": {
         "phpstan/phpstan": "2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "php-64bit": "*",
-        "ext-encoding": "~0.2.1"
+        "ext-encoding": "~0.4.0"
     },
     "require-dev": {
         "phpstan/phpstan": "2.1.0",

--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -23,29 +23,27 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
+use pmmp\encoding\ByteBuffer;
+use pmmp\encoding\DataDecodeException;
 use pocketmine\nbt\tag\Tag;
-use pocketmine\utils\Binary;
-use pocketmine\utils\BinaryDataException;
-use pocketmine\utils\BinaryStream;
 use function strlen;
 
 /**
  * Base Named Binary Tag encoder/decoder
  */
 abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
-	/** @var BinaryStream */
-	protected $buffer;
+	protected ByteBuffer $buffer;
 
 	public function __construct(){
-		$this->buffer = new BinaryStream();
+		$this->buffer = new ByteBuffer();
 	}
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 * @throws NbtDataException
 	 */
 	private function readRoot(int $maxDepth) : TreeRoot{
-		$type = $this->readByte();
+		$type = $this->buffer->readUnsignedByte();
 		if($type === NBT::TAG_End){
 			throw new NbtDataException("Found TAG_End at the start of buffer");
 		}
@@ -62,11 +60,12 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	public function read(string $buffer, int &$offset = 0, int $maxDepth = 0) : TreeRoot{
-		$this->buffer = new BinaryStream($buffer, $offset);
+		$this->buffer = new ByteBuffer($buffer);
+		$this->buffer->setOffset($offset);
 
 		try{
 			$data = $this->readRoot($maxDepth);
-		}catch(BinaryDataException $e){
+		}catch(DataDecodeException $e){
 			throw new NbtDataException($e->getMessage(), 0, $e);
 		}
 		$offset = $this->buffer->getOffset();
@@ -85,7 +84,8 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	public function readHeadless(string $buffer, int $rootType, int &$offset = 0, int $maxDepth = 0) : Tag{
-		$this->buffer = new BinaryStream($buffer, $offset);
+		$this->buffer = new ByteBuffer($buffer);
+		$this->buffer->setOffset($offset);
 
 		$data = NBT::createTag($rootType, $this, new ReaderTracker($maxDepth));
 		$offset = $this->buffer->getOffset();
@@ -102,14 +102,15 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	public function readMultiple(string $buffer, int $maxDepth = 0) : array{
-		$this->buffer = new BinaryStream($buffer);
+		$this->buffer = new ByteBuffer($buffer);
 
 		$retval = [];
 
-		while(!$this->buffer->feof()){
+		$strlen = strlen($buffer);
+		while($this->buffer->getOffset() < $strlen){
 			try{
 				$retval[] = $this->readRoot($maxDepth);
-			}catch(BinaryDataException $e){
+			}catch(DataDecodeException $e){
 				throw new NbtDataException($e->getMessage(), 0, $e);
 			}
 		}
@@ -118,17 +119,17 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	private function writeRoot(TreeRoot $root) : void{
-		$this->writeByte($root->getTag()->getType());
+		$this->buffer->writeUnsignedByte($root->getTag()->getType());
 		$this->writeString($root->getName());
 		$root->getTag()->write($this);
 	}
 
 	public function write(TreeRoot $data) : string{
-		$this->buffer = new BinaryStream();
+		$this->buffer = new ByteBuffer();
 
 		$this->writeRoot($data);
 
-		return $this->buffer->getBuffer();
+		return $this->buffer->toString();
 	}
 
 	/**
@@ -138,32 +139,32 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @see BaseNbtSerializer::readHeadless()
 	 */
 	public function writeHeadless(Tag $data) : string{
-		$this->buffer = new BinaryStream();
+		$this->buffer = new ByteBuffer();
 		$data->write($this);
-		return $this->buffer->getBuffer();
+		return $this->buffer->toString();
 	}
 
 	/**
 	 * @param TreeRoot[] $data
 	 */
 	public function writeMultiple(array $data) : string{
-		$this->buffer = new BinaryStream();
+		$this->buffer = new ByteBuffer();
 		foreach($data as $root){
 			$this->writeRoot($root);
 		}
-		return $this->buffer->getBuffer();
+		return $this->buffer->toString();
 	}
 
 	public function readByte() : int{
-		return $this->buffer->getByte();
+		return $this->buffer->readUnsignedByte();
 	}
 
 	public function readSignedByte() : int{
-		return Binary::signByte($this->buffer->getByte());
+		return $this->buffer->readSignedByte();
 	}
 
 	public function writeByte(int $v) : void{
-		$this->buffer->putByte($v);
+		$this->buffer->writeUnsignedByte($v);
 	}
 
 	public function readByteArray() : string{
@@ -171,12 +172,12 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 		if($length < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($length < 0)");
 		}
-		return $this->buffer->get($length);
+		return $this->buffer->readByteArray($length);
 	}
 
 	public function writeByteArray(string $v) : void{
 		$this->writeInt(strlen($v)); //TODO: overflow
-		$this->buffer->put($v);
+		$this->buffer->writeByteArray($v);
 	}
 
 	/**
@@ -200,7 +201,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	public function readString() : string{
-		return $this->buffer->get(self::checkReadStringLength($this->readShort()));
+		return $this->buffer->readByteArray(self::checkReadStringLength($this->readShort()));
 	}
 
 	/**
@@ -208,6 +209,6 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 */
 	public function writeString(string $v) : void{
 		$this->writeShort(self::checkWriteStringLength(strlen($v)));
-		$this->buffer->put($v);
+		$this->buffer->writeByteArray($v);
 	}
 }

--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -61,14 +61,14 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 */
 	public function read(string $buffer, int &$offset = 0, int $maxDepth = 0) : TreeRoot{
 		$this->buffer = new ByteBuffer($buffer);
-		$this->buffer->setOffset($offset);
+		$this->buffer->setReadOffset($offset);
 
 		try{
 			$data = $this->readRoot($maxDepth);
 		}catch(DataDecodeException $e){
 			throw new NbtDataException($e->getMessage(), 0, $e);
 		}
-		$offset = $this->buffer->getOffset();
+		$offset = $this->buffer->getReadOffset();
 
 		return $data;
 	}
@@ -85,10 +85,10 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 */
 	public function readHeadless(string $buffer, int $rootType, int &$offset = 0, int $maxDepth = 0) : Tag{
 		$this->buffer = new ByteBuffer($buffer);
-		$this->buffer->setOffset($offset);
+		$this->buffer->setReadOffset($offset);
 
 		$data = NBT::createTag($rootType, $this, new ReaderTracker($maxDepth));
-		$offset = $this->buffer->getOffset();
+		$offset = $this->buffer->getReadOffset();
 
 		return $data;
 	}
@@ -106,8 +106,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 
 		$retval = [];
 
-		$strlen = strlen($buffer);
-		while($this->buffer->getOffset() < $strlen){
+		while($this->buffer->getReadOffset() < $this->buffer->getUsedLength()){
 			try{
 				$retval[] = $this->readRoot($maxDepth);
 			}catch(DataDecodeException $e){

--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -184,8 +184,8 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	protected static function checkReadStringLength(int $len) : int{
-		if($len > 32767){
-			throw new NbtDataException("NBT string length too large ($len > 32767)");
+		if($len > NBT::MAX_STRING_LENGTH){
+			throw new NbtDataException("NBT string length too large ($len > " . NBT::MAX_STRING_LENGTH . ")");
 		}
 		return $len;
 	}
@@ -194,8 +194,8 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws \InvalidArgumentException
 	 */
 	protected static function checkWriteStringLength(int $len) : int{
-		if($len > 32767){
-			throw new \InvalidArgumentException("NBT string length too large ($len > 32767)");
+		if($len > NBT::MAX_STRING_LENGTH){
+			throw new \InvalidArgumentException("NBT string length too large ($len > " . NBT::MAX_STRING_LENGTH . ")");
 		}
 		return $len;
 	}

--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -24,7 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\nbt;
 
 use pmmp\encoding\Byte;
-use pmmp\encoding\ByteBuffer;
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
 use pmmp\encoding\DataDecodeException;
 use pocketmine\nbt\tag\Tag;
 use function strlen;
@@ -33,18 +34,15 @@ use function strlen;
  * Base Named Binary Tag encoder/decoder
  */
 abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
-	protected ByteBuffer $buffer;
-
-	public function __construct(){
-		$this->buffer = new ByteBuffer();
-	}
+	protected ByteBufferReader $reader;
+	protected ByteBufferWriter $writer;
 
 	/**
 	 * @throws DataDecodeException
 	 * @throws NbtDataException
 	 */
 	private function readRoot(int $maxDepth) : TreeRoot{
-		$type = Byte::readUnsigned($this->buffer);
+		$type = Byte::readUnsigned($this->reader);
 		if($type === NBT::TAG_End){
 			throw new NbtDataException("Found TAG_End at the start of buffer");
 		}
@@ -61,15 +59,15 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	public function read(string $buffer, int &$offset = 0, int $maxDepth = 0) : TreeRoot{
-		$this->buffer = new ByteBuffer($buffer);
-		$this->buffer->setReadOffset($offset);
+		$this->reader = new ByteBufferReader($buffer);
+		$this->reader->setOffset($offset);
 
 		try{
 			$data = $this->readRoot($maxDepth);
 		}catch(DataDecodeException $e){
 			throw new NbtDataException($e->getMessage(), 0, $e);
 		}
-		$offset = $this->buffer->getReadOffset();
+		$offset = $this->reader->getOffset();
 
 		return $data;
 	}
@@ -85,11 +83,11 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	public function readHeadless(string $buffer, int $rootType, int &$offset = 0, int $maxDepth = 0) : Tag{
-		$this->buffer = new ByteBuffer($buffer);
-		$this->buffer->setReadOffset($offset);
+		$this->reader = new ByteBufferReader($buffer);
+		$this->reader->setOffset($offset);
 
 		$data = NBT::createTag($rootType, $this, new ReaderTracker($maxDepth));
-		$offset = $this->buffer->getReadOffset();
+		$offset = $this->reader->getOffset();
 
 		return $data;
 	}
@@ -104,11 +102,12 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	public function readMultiple(string $buffer, int $maxDepth = 0) : array{
-		$this->buffer = new ByteBuffer($buffer);
+		$this->reader = new ByteBufferReader($buffer);
 
 		$retval = [];
 
-		while($this->buffer->getReadOffset() < $this->buffer->getUsedLength()){
+		$length = strlen($this->reader->getData());
+		while($this->reader->getOffset() < $length){
 			try{
 				$retval[] = $this->readRoot($maxDepth);
 			}catch(DataDecodeException $e){
@@ -120,17 +119,17 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	private function writeRoot(TreeRoot $root) : void{
-		Byte::writeUnsigned($this->buffer, $root->getTag()->getType());
+		Byte::writeUnsigned($this->writer, $root->getTag()->getType());
 		$this->writeString($root->getName());
 		$root->getTag()->write($this);
 	}
 
 	public function write(TreeRoot $data) : string{
-		$this->buffer = new ByteBuffer();
+		$this->writer = new ByteBufferWriter();
 
 		$this->writeRoot($data);
 
-		return $this->buffer->toString();
+		return $this->writer->getData();
 	}
 
 	/**
@@ -140,32 +139,32 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @see BaseNbtSerializer::readHeadless()
 	 */
 	public function writeHeadless(Tag $data) : string{
-		$this->buffer = new ByteBuffer();
+		$this->writer = new ByteBufferWriter();
 		$data->write($this);
-		return $this->buffer->toString();
+		return $this->writer->getData();
 	}
 
 	/**
 	 * @param TreeRoot[] $data
 	 */
 	public function writeMultiple(array $data) : string{
-		$this->buffer = new ByteBuffer();
+		$this->writer = new ByteBufferWriter();
 		foreach($data as $root){
 			$this->writeRoot($root);
 		}
-		return $this->buffer->toString();
+		return $this->writer->getData();
 	}
 
 	public function readByte() : int{
-		return Byte::readUnsigned($this->buffer);
+		return Byte::readUnsigned($this->reader);
 	}
 
 	public function readSignedByte() : int{
-		return Byte::readSigned($this->buffer);
+		return Byte::readSigned($this->reader);
 	}
 
 	public function writeByte(int $v) : void{
-		Byte::writeUnsigned($this->buffer, $v);
+		Byte::writeUnsigned($this->writer, $v);
 	}
 
 	public function readByteArray() : string{
@@ -173,12 +172,12 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 		if($length < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($length < 0)");
 		}
-		return $this->buffer->readByteArray($length);
+		return $this->reader->readByteArray($length);
 	}
 
 	public function writeByteArray(string $v) : void{
 		$this->writeInt(strlen($v)); //TODO: overflow
-		$this->buffer->writeByteArray($v);
+		$this->writer->writeByteArray($v);
 	}
 
 	/**
@@ -202,7 +201,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	public function readString() : string{
-		return $this->buffer->readByteArray(self::checkReadStringLength($this->readShort()));
+		return $this->reader->readByteArray(self::checkReadStringLength($this->readShort()));
 	}
 
 	/**
@@ -210,6 +209,6 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 */
 	public function writeString(string $v) : void{
 		$this->writeShort(self::checkWriteStringLength(strlen($v)));
-		$this->buffer->writeByteArray($v);
+		$this->writer->writeByteArray($v);
 	}
 }

--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
+use pmmp\encoding\Byte;
 use pmmp\encoding\ByteBuffer;
 use pmmp\encoding\DataDecodeException;
 use pocketmine\nbt\tag\Tag;
@@ -43,7 +44,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 * @throws NbtDataException
 	 */
 	private function readRoot(int $maxDepth) : TreeRoot{
-		$type = $this->buffer->readUnsignedByte();
+		$type = Byte::readUnsigned($this->buffer);
 		if($type === NBT::TAG_End){
 			throw new NbtDataException("Found TAG_End at the start of buffer");
 		}
@@ -119,7 +120,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	private function writeRoot(TreeRoot $root) : void{
-		$this->buffer->writeUnsignedByte($root->getTag()->getType());
+		Byte::writeUnsigned($this->buffer, $root->getTag()->getType());
 		$this->writeString($root->getName());
 		$root->getTag()->write($this);
 	}
@@ -156,15 +157,15 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	public function readByte() : int{
-		return $this->buffer->readUnsignedByte();
+		return Byte::readUnsigned($this->buffer);
 	}
 
 	public function readSignedByte() : int{
-		return $this->buffer->readSignedByte();
+		return Byte::readSigned($this->buffer);
 	}
 
 	public function writeByte(int $v) : void{
-		$this->buffer->writeUnsignedByte($v);
+		Byte::writeUnsigned($this->buffer, $v);
 	}
 
 	public function readByteArray() : string{

--- a/src/BigEndianNbtSerializer.php
+++ b/src/BigEndianNbtSerializer.php
@@ -32,47 +32,47 @@ use function unpack;
 class BigEndianNbtSerializer extends BaseNbtSerializer{
 
 	public function readShort() : int{
-		return $this->buffer->getShort();
+		return $this->buffer->readUnsignedShortBE();
 	}
 
 	public function readSignedShort() : int{
-		return $this->buffer->getSignedShort();
+		return $this->buffer->readSignedShortBE();
 	}
 
 	public function writeShort(int $v) : void{
-		$this->buffer->putShort($v);
+		$this->buffer->writeUnsignedShortBE($v);
 	}
 
 	public function readInt() : int{
-		return $this->buffer->getInt();
+		return $this->buffer->readSignedIntBE();
 	}
 
 	public function writeInt(int $v) : void{
-		$this->buffer->putInt($v);
+		$this->buffer->writeSignedIntBE($v);
 	}
 
 	public function readLong() : int{
-		return $this->buffer->getLong();
+		return $this->buffer->readSignedLongBE();
 	}
 
 	public function writeLong(int $v) : void{
-		$this->buffer->putLong($v);
+		$this->buffer->writeSignedLongBE($v);
 	}
 
 	public function readFloat() : float{
-		return $this->buffer->getFloat();
+		return $this->buffer->readFloatBE();
 	}
 
 	public function writeFloat(float $v) : void{
-		$this->buffer->putFloat($v);
+		$this->buffer->writeFloatBE($v);
 	}
 
 	public function readDouble() : float{
-		return $this->buffer->getDouble();
+		return $this->buffer->readDoubleBE();
 	}
 
 	public function writeDouble(float $v) : void{
-		$this->buffer->putDouble($v);
+		$this->buffer->writeDoubleBE($v);
 	}
 
 	public function readIntArray() : array{
@@ -80,13 +80,13 @@ class BigEndianNbtSerializer extends BaseNbtSerializer{
 		if($len < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($len < 0)");
 		}
-		$unpacked = unpack("N*", $this->buffer->get($len * 4));
+		$unpacked = unpack("N*", $this->buffer->readByteArray($len * 4));
 		assert($unpacked !== false, "The formatting string is valid, and we gave a multiple of 4 bytes");
 		return array_values($unpacked);
 	}
 
 	public function writeIntArray(array $array) : void{
 		$this->writeInt(count($array));
-		$this->buffer->put(pack("N*", ...$array));
+		$this->buffer->writeByteArray(pack("N*", ...$array));
 	}
 }

--- a/src/BigEndianNbtSerializer.php
+++ b/src/BigEndianNbtSerializer.php
@@ -24,56 +24,52 @@ declare(strict_types=1);
 namespace pocketmine\nbt;
 
 use pmmp\encoding\BE;
-use function array_values;
-use function assert;
 use function count;
-use function pack;
-use function unpack;
 
 class BigEndianNbtSerializer extends BaseNbtSerializer{
 
 	public function readShort() : int{
-		return BE::readUnsignedShort($this->buffer);
+		return BE::readUnsignedShort($this->reader);
 	}
 
 	public function readSignedShort() : int{
-		return BE::readSignedShort($this->buffer);
+		return BE::readSignedShort($this->reader);
 	}
 
 	public function writeShort(int $v) : void{
-		BE::writeUnsignedShort($this->buffer, $v);
+		BE::writeUnsignedShort($this->writer, $v);
 	}
 
 	public function readInt() : int{
-		return BE::readSignedInt($this->buffer);
+		return BE::readSignedInt($this->reader);
 	}
 
 	public function writeInt(int $v) : void{
-		BE::writeSignedInt($this->buffer, $v);
+		BE::writeSignedInt($this->writer, $v);
 	}
 
 	public function readLong() : int{
-		return BE::readSignedLong($this->buffer);
+		return BE::readSignedLong($this->reader);
 	}
 
 	public function writeLong(int $v) : void{
-		BE::writeSignedLong($this->buffer, $v);
+		BE::writeSignedLong($this->writer, $v);
 	}
 
 	public function readFloat() : float{
-		return BE::readFloat($this->buffer);
+		return BE::readFloat($this->reader);
 	}
 
 	public function writeFloat(float $v) : void{
-		BE::writeFloat($this->buffer, $v);
+		BE::writeFloat($this->writer, $v);
 	}
 
 	public function readDouble() : float{
-		return BE::readDouble($this->buffer);
+		return BE::readDouble($this->reader);
 	}
 
 	public function writeDouble(float $v) : void{
-		BE::writeDouble($this->buffer, $v);
+		BE::writeDouble($this->writer, $v);
 	}
 
 	public function readIntArray() : array{
@@ -81,14 +77,11 @@ class BigEndianNbtSerializer extends BaseNbtSerializer{
 		if($len < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($len < 0)");
 		}
-		/** @var array<int>|false $unpacked */
-		$unpacked = unpack("N*", $this->buffer->readByteArray($len * 4));
-		assert($unpacked !== false, "The formatting string is valid, and we gave a multiple of 4 bytes");
-		return array_values($unpacked);
+		return BE::readSignedIntArray($this->reader, $len);
 	}
 
 	public function writeIntArray(array $array) : void{
 		$this->writeInt(count($array));
-		$this->buffer->writeByteArray(pack("N*", ...$array));
+		BE::writeSignedIntArray($this->writer, $array);
 	}
 }

--- a/src/BigEndianNbtSerializer.php
+++ b/src/BigEndianNbtSerializer.php
@@ -24,7 +24,11 @@ declare(strict_types=1);
 namespace pocketmine\nbt;
 
 use pmmp\encoding\BE;
+use function array_values;
+use function assert;
 use function count;
+use function pack;
+use function unpack;
 
 class BigEndianNbtSerializer extends BaseNbtSerializer{
 
@@ -77,11 +81,14 @@ class BigEndianNbtSerializer extends BaseNbtSerializer{
 		if($len < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($len < 0)");
 		}
-		return BE::readSignedIntArray($this->reader, $len);
+		/** @var array<int>|false $unpacked */
+		$unpacked = unpack("N*", $this->reader->readByteArray($len * 4));
+		assert($unpacked !== false, "The formatting string is valid, and we gave a multiple of 4 bytes");
+		return array_values($unpacked);
 	}
 
 	public function writeIntArray(array $array) : void{
 		$this->writeInt(count($array));
-		BE::writeSignedIntArray($this->writer, $array);
+		$this->writer->writeByteArray(pack("N*", ...$array));
 	}
 }

--- a/src/BigEndianNbtSerializer.php
+++ b/src/BigEndianNbtSerializer.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
+use pmmp\encoding\BE;
 use function array_values;
 use function assert;
 use function count;
@@ -32,47 +33,47 @@ use function unpack;
 class BigEndianNbtSerializer extends BaseNbtSerializer{
 
 	public function readShort() : int{
-		return $this->buffer->readUnsignedShortBE();
+		return BE::readUnsignedShort($this->buffer);
 	}
 
 	public function readSignedShort() : int{
-		return $this->buffer->readSignedShortBE();
+		return BE::readSignedShort($this->buffer);
 	}
 
 	public function writeShort(int $v) : void{
-		$this->buffer->writeUnsignedShortBE($v);
+		BE::writeUnsignedShort($this->buffer, $v);
 	}
 
 	public function readInt() : int{
-		return $this->buffer->readSignedIntBE();
+		return BE::readSignedInt($this->buffer);
 	}
 
 	public function writeInt(int $v) : void{
-		$this->buffer->writeSignedIntBE($v);
+		BE::writeSignedInt($this->buffer, $v);
 	}
 
 	public function readLong() : int{
-		return $this->buffer->readSignedLongBE();
+		return BE::readSignedLong($this->buffer);
 	}
 
 	public function writeLong(int $v) : void{
-		$this->buffer->writeSignedLongBE($v);
+		BE::writeSignedLong($this->buffer, $v);
 	}
 
 	public function readFloat() : float{
-		return $this->buffer->readFloatBE();
+		return BE::readFloat($this->buffer);
 	}
 
 	public function writeFloat(float $v) : void{
-		$this->buffer->writeFloatBE($v);
+		BE::writeFloat($this->buffer, $v);
 	}
 
 	public function readDouble() : float{
-		return $this->buffer->readDoubleBE();
+		return BE::readDouble($this->buffer);
 	}
 
 	public function writeDouble(float $v) : void{
-		$this->buffer->writeDoubleBE($v);
+		BE::writeDouble($this->buffer, $v);
 	}
 
 	public function readIntArray() : array{

--- a/src/JsonNbtParser.php
+++ b/src/JsonNbtParser.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
-use pmmp\encoding\ByteBuffer;
+use pmmp\encoding\ByteBufferReader;
 use pmmp\encoding\DataDecodeException;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
@@ -36,6 +36,7 @@ use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\nbt\tag\Tag;
 use function is_numeric;
+use function strlen;
 use function strpos;
 use function strtolower;
 use function substr;
@@ -49,7 +50,7 @@ class JsonNbtParser{
 	 * @throws NbtDataException
 	 */
 	public static function parseJson(string $data) : CompoundTag{
-		$stream = new ByteBuffer(trim($data, " \r\n\t"));
+		$stream = new ByteBufferReader(trim($data, " \r\n\t"));
 
 		try{
 			if(($b = $stream->readByteArray(1)) !== "{"){
@@ -57,11 +58,11 @@ class JsonNbtParser{
 			}
 			$ret = self::parseCompound($stream); //don't return directly, syntax needs to be validated
 		}catch(NbtDataException $e){
-			throw new NbtDataException($e->getMessage() . " at offset " . $stream->getReadOffset());
+			throw new NbtDataException($e->getMessage() . " at offset " . $stream->getOffset());
 		}catch(DataDecodeException $e){
-			throw new NbtDataException("Syntax error: " . $e->getMessage() . " at offset " . $stream->getReadOffset());
+			throw new NbtDataException("Syntax error: " . $e->getMessage() . " at offset " . $stream->getOffset());
 		}
-		$leftover = $stream->getUsedLength() - $stream->getReadOffset();
+		$leftover = strlen($stream->getData()) - $stream->getOffset();
 		if($leftover > 0){
 			throw new NbtDataException("Syntax error: unexpected trailing characters after end of tag: " . $stream->readByteArray($leftover));
 		}
@@ -73,11 +74,12 @@ class JsonNbtParser{
 	 * @throws DataDecodeException
 	 * @throws NbtDataException
 	 */
-	private static function parseList(ByteBuffer $stream) : ListTag{
+	private static function parseList(ByteBufferReader $stream) : ListTag{
 		$retval = new ListTag();
 
 		if(self::skipWhitespace($stream, "]")){
-			while($stream->getReadOffset() < $stream->getUsedLength()){
+			$len = strlen($stream->getData());
+			while($stream->getOffset() < $len){
 				try{
 					$value = self::readValue($stream);
 				}catch(InvalidTagValueException $e){
@@ -103,11 +105,12 @@ class JsonNbtParser{
 	 * @throws DataDecodeException
 	 * @throws NbtDataException
 	 */
-	private static function parseCompound(ByteBuffer $stream) : CompoundTag{
+	private static function parseCompound(ByteBufferReader $stream) : CompoundTag{
 		$retval = new CompoundTag();
 
 		if(self::skipWhitespace($stream, "}")){
-			while($stream->getReadOffset() < $stream->getUsedLength()){
+			$len = strlen($stream->getData());
+			while($stream->getOffset() < $len){
 				$k = self::readKey($stream);
 				if($retval->getTag($k) !== null){
 					throw new NbtDataException("Syntax error: duplicate compound leaf node '$k'");
@@ -133,8 +136,9 @@ class JsonNbtParser{
 	 * @throws DataDecodeException
 	 * @throws NbtDataException
 	 */
-	private static function skipWhitespace(ByteBuffer $stream, string $terminator) : bool{
-		while($stream->getReadOffset() < $stream->getUsedLength()){
+	private static function skipWhitespace(ByteBufferReader $stream, string $terminator) : bool{
+		$len = strlen($stream->getData());
+		while($stream->getOffset() < $len){
 			$b = $stream->readByteArray(1);
 			if($b === $terminator){
 				return false;
@@ -143,7 +147,7 @@ class JsonNbtParser{
 				continue;
 			}
 
-			$stream->setReadOffset($stream->getReadOffset() - 1);
+			$stream->setOffset($stream->getOffset() - 1);
 			return true;
 		}
 
@@ -155,8 +159,9 @@ class JsonNbtParser{
 	 * @throws DataDecodeException
 	 * @throws NbtDataException
 	 */
-	private static function readBreak(ByteBuffer $stream, string $terminator) : bool{
-		if($stream->getReadOffset() >= $stream->getUsedLength()){
+	private static function readBreak(ByteBufferReader $stream, string $terminator) : bool{
+		$len = strlen($stream->getData());
+		if($stream->getOffset() >= $len){
 			throw new NbtDataException("Syntax error: unexpected end of stream, expected '$terminator'");
 		}
 		$c = $stream->readByteArray(1);
@@ -175,7 +180,7 @@ class JsonNbtParser{
 	 * @throws NbtDataException
 	 * @throws InvalidTagValueException
 	 */
-	private static function readValue(ByteBuffer $stream) : Tag{
+	private static function readValue(ByteBufferReader $stream) : Tag{
 		$value = "";
 		$inQuotes = false;
 
@@ -184,7 +189,8 @@ class JsonNbtParser{
 		/** @var Tag|null $retval */
 		$retval = null;
 
-		while($stream->getReadOffset() < $stream->getUsedLength()){
+		$len = strlen($stream->getData());
+		while($stream->getOffset() < $len){
 			$c = $stream->readByteArray(1);
 
 			if($inQuotes){ //anything is allowed inside quotes, except unescaped quotes
@@ -199,7 +205,7 @@ class JsonNbtParser{
 				}
 			}else{
 				if($c === "," or $c === "}" or $c === "]"){ //end of parent tag
-					$stream->setReadOffset($stream->getReadOffset() - 1); //the caller needs to be able to read this character
+					$stream->setOffset($stream->getOffset() - 1); //the caller needs to be able to read this character
 					$foundEnd = true;
 					break;
 				}
@@ -293,13 +299,14 @@ class JsonNbtParser{
 	 * @throws DataDecodeException
 	 * @throws NbtDataException
 	 */
-	private static function readKey(ByteBuffer $stream) : string{
+	private static function readKey(ByteBufferReader $stream) : string{
 		$key = "";
 
 		$inQuotes = false;
 		$foundEnd = false;
 
-		while($stream->getReadOffset() < $stream->getUsedLength()){
+		$len = strlen($stream->getData());
+		while($stream->getOffset() < $len){
 			$c = $stream->readByteArray(1);
 
 			if($inQuotes){

--- a/src/LittleEndianNbtSerializer.php
+++ b/src/LittleEndianNbtSerializer.php
@@ -32,47 +32,47 @@ use function unpack;
 class LittleEndianNbtSerializer extends BaseNbtSerializer{
 
 	public function readShort() : int{
-		return $this->buffer->getLShort();
+		return $this->buffer->readUnsignedShortLE();
 	}
 
 	public function readSignedShort() : int{
-		return $this->buffer->getSignedLShort();
+		return $this->buffer->readSignedShortLE();
 	}
 
 	public function writeShort(int $v) : void{
-		$this->buffer->putLShort($v);
+		$this->buffer->writeUnsignedShortLE($v);
 	}
 
 	public function readInt() : int{
-		return $this->buffer->getLInt();
+		return $this->buffer->readSignedIntLE();
 	}
 
 	public function writeInt(int $v) : void{
-		$this->buffer->putLInt($v);
+		$this->buffer->writeSignedIntLE($v);
 	}
 
 	public function readLong() : int{
-		return $this->buffer->getLLong();
+		return $this->buffer->readSignedLongLE();
 	}
 
 	public function writeLong(int $v) : void{
-		$this->buffer->putLLong($v);
+		$this->buffer->writeSignedLongLE($v);
 	}
 
 	public function readFloat() : float{
-		return $this->buffer->getLFloat();
+		return $this->buffer->readFloatLE();
 	}
 
 	public function writeFloat(float $v) : void{
-		$this->buffer->putLFloat($v);
+		$this->buffer->writeFloatLE($v);
 	}
 
 	public function readDouble() : float{
-		return $this->buffer->getLDouble();
+		return $this->buffer->readDoubleLE();
 	}
 
 	public function writeDouble(float $v) : void{
-		$this->buffer->putLDouble($v);
+		$this->buffer->writeDoubleLE($v);
 	}
 
 	public function readIntArray() : array{
@@ -80,13 +80,13 @@ class LittleEndianNbtSerializer extends BaseNbtSerializer{
 		if($len < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($len < 0)");
 		}
-		$unpacked = unpack("V*", $this->buffer->get($len * 4));
+		$unpacked = unpack("V*", $this->buffer->readByteArray($len * 4));
 		assert($unpacked !== false, "The formatting string is valid, and we gave a multiple of 4 bytes");
 		return array_values($unpacked);
 	}
 
 	public function writeIntArray(array $array) : void{
 		$this->writeInt(count($array));
-		$this->buffer->put(pack("V*", ...$array));
+		$this->buffer->writeByteArray(pack("V*", ...$array));
 	}
 }

--- a/src/LittleEndianNbtSerializer.php
+++ b/src/LittleEndianNbtSerializer.php
@@ -24,56 +24,52 @@ declare(strict_types=1);
 namespace pocketmine\nbt;
 
 use pmmp\encoding\LE;
-use function array_values;
-use function assert;
 use function count;
-use function pack;
-use function unpack;
 
 class LittleEndianNbtSerializer extends BaseNbtSerializer{
 
 	public function readShort() : int{
-		return LE::readUnsignedShort($this->buffer);
+		return LE::readUnsignedShort($this->reader);
 	}
 
 	public function readSignedShort() : int{
-		return LE::readSignedShort($this->buffer);
+		return LE::readSignedShort($this->reader);
 	}
 
 	public function writeShort(int $v) : void{
-		LE::writeUnsignedShort($this->buffer, $v);
+		LE::writeUnsignedShort($this->writer, $v);
 	}
 
 	public function readInt() : int{
-		return LE::readSignedInt($this->buffer);
+		return LE::readSignedInt($this->reader);
 	}
 
 	public function writeInt(int $v) : void{
-		LE::writeSignedInt($this->buffer, $v);
+		LE::writeSignedInt($this->writer, $v);
 	}
 
 	public function readLong() : int{
-		return LE::readSignedLong($this->buffer);
+		return LE::readSignedLong($this->reader);
 	}
 
 	public function writeLong(int $v) : void{
-		LE::writeSignedLong($this->buffer, $v);
+		LE::writeSignedLong($this->writer, $v);
 	}
 
 	public function readFloat() : float{
-		return LE::readFloat($this->buffer);
+		return LE::readFloat($this->reader);
 	}
 
 	public function writeFloat(float $v) : void{
-		LE::writeFloat($this->buffer, $v);
+		LE::writeFloat($this->writer, $v);
 	}
 
 	public function readDouble() : float{
-		return LE::readDouble($this->buffer);
+		return LE::readDouble($this->reader);
 	}
 
 	public function writeDouble(float $v) : void{
-		LE::writeDouble($this->buffer, $v);
+		LE::writeDouble($this->writer, $v);
 	}
 
 	public function readIntArray() : array{
@@ -81,14 +77,11 @@ class LittleEndianNbtSerializer extends BaseNbtSerializer{
 		if($len < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($len < 0)");
 		}
-		/** @var array<int>|false $unpacked */
-		$unpacked = unpack("V*", $this->buffer->readByteArray($len * 4));
-		assert($unpacked !== false, "The formatting string is valid, and we gave a multiple of 4 bytes");
-		return array_values($unpacked);
+		return LE::readSignedIntArray($this->reader, $len);
 	}
 
 	public function writeIntArray(array $array) : void{
 		$this->writeInt(count($array));
-		$this->buffer->writeByteArray(pack("V*", ...$array));
+		LE::writeSignedIntArray($this->writer, $array);
 	}
 }

--- a/src/LittleEndianNbtSerializer.php
+++ b/src/LittleEndianNbtSerializer.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
+use pmmp\encoding\LE;
 use function array_values;
 use function assert;
 use function count;
@@ -32,47 +33,47 @@ use function unpack;
 class LittleEndianNbtSerializer extends BaseNbtSerializer{
 
 	public function readShort() : int{
-		return $this->buffer->readUnsignedShortLE();
+		return LE::readUnsignedShort($this->buffer);
 	}
 
 	public function readSignedShort() : int{
-		return $this->buffer->readSignedShortLE();
+		return LE::readSignedShort($this->buffer);
 	}
 
 	public function writeShort(int $v) : void{
-		$this->buffer->writeUnsignedShortLE($v);
+		LE::writeUnsignedShort($this->buffer, $v);
 	}
 
 	public function readInt() : int{
-		return $this->buffer->readSignedIntLE();
+		return LE::readSignedInt($this->buffer);
 	}
 
 	public function writeInt(int $v) : void{
-		$this->buffer->writeSignedIntLE($v);
+		LE::writeSignedInt($this->buffer, $v);
 	}
 
 	public function readLong() : int{
-		return $this->buffer->readSignedLongLE();
+		return LE::readSignedLong($this->buffer);
 	}
 
 	public function writeLong(int $v) : void{
-		$this->buffer->writeSignedLongLE($v);
+		LE::writeSignedLong($this->buffer, $v);
 	}
 
 	public function readFloat() : float{
-		return $this->buffer->readFloatLE();
+		return LE::readFloat($this->buffer);
 	}
 
 	public function writeFloat(float $v) : void{
-		$this->buffer->writeFloatLE($v);
+		LE::writeFloat($this->buffer, $v);
 	}
 
 	public function readDouble() : float{
-		return $this->buffer->readDoubleLE();
+		return LE::readDouble($this->buffer);
 	}
 
 	public function writeDouble(float $v) : void{
-		$this->buffer->writeDoubleLE($v);
+		LE::writeDouble($this->buffer, $v);
 	}
 
 	public function readIntArray() : array{

--- a/src/LittleEndianNbtSerializer.php
+++ b/src/LittleEndianNbtSerializer.php
@@ -24,7 +24,11 @@ declare(strict_types=1);
 namespace pocketmine\nbt;
 
 use pmmp\encoding\LE;
+use function array_values;
+use function assert;
 use function count;
+use function pack;
+use function unpack;
 
 class LittleEndianNbtSerializer extends BaseNbtSerializer{
 
@@ -77,11 +81,14 @@ class LittleEndianNbtSerializer extends BaseNbtSerializer{
 		if($len < 0){
 			throw new NbtDataException("Array length cannot be less than zero ($len < 0)");
 		}
-		return LE::readSignedIntArray($this->reader, $len);
+		/** @var array<int>|false $unpacked */
+		$unpacked = unpack("V*", $this->reader->readByteArray($len * 4));
+		assert($unpacked !== false, "The formatting string is valid, and we gave a multiple of 4 bytes");
+		return array_values($unpacked);
 	}
 
 	public function writeIntArray(array $array) : void{
 		$this->writeInt(count($array));
-		LE::writeSignedIntArray($this->writer, $array);
+		$this->writer->writeByteArray(pack("V*", ...$array));
 	}
 }

--- a/src/NBT.php
+++ b/src/NBT.php
@@ -40,6 +40,7 @@ use pocketmine\nbt\tag\StringTag;
 use pocketmine\nbt\tag\Tag;
 
 abstract class NBT{
+	public const MAX_STRING_LENGTH = 32767;
 
 	public const TAG_End = 0;
 	public const TAG_Byte = 1;

--- a/src/NbtStreamReader.php
+++ b/src/NbtStreamReader.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt;
 
-use pocketmine\utils\BinaryDataException;
+use pmmp\encoding\DataDecodeException;
 
 /**
  * @internal
@@ -31,58 +31,58 @@ use pocketmine\utils\BinaryDataException;
 interface NbtStreamReader{
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readByte() : int;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readSignedByte() : int;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readShort() : int;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readSignedShort() : int;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readInt() : int;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readLong() : int;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readFloat() : float;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readDouble() : float;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readByteArray() : string;
 
 	/**
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readString() : string;
 
 	/**
 	 * @return int[]
-	 * @throws BinaryDataException
+	 * @throws DataDecodeException
 	 */
 	public function readIntArray() : array;
 }

--- a/src/TreeRoot.php
+++ b/src/TreeRoot.php
@@ -25,7 +25,6 @@ namespace pocketmine\nbt;
 
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\Tag;
-use pocketmine\utils\Limits;
 use function sprintf;
 use function strlen;
 
@@ -40,8 +39,8 @@ class TreeRoot{
 	private $name;
 
 	public function __construct(Tag $root, string $name = ""){
-		if(strlen($name) > Limits::INT16_MAX){
-			throw new \InvalidArgumentException(sprintf("Tag name must be at most %d bytes, but got %d bytes", Limits::INT16_MAX, strlen($name)));
+		if(strlen($name) > NBT::MAX_STRING_LENGTH){
+			throw new \InvalidArgumentException(sprintf("Tag name must be at most %d bytes, but got %d bytes", NBT::MAX_STRING_LENGTH, strlen($name)));
 		}
 		$this->root = $root;
 		$this->name = $name;

--- a/src/tag/CompoundTag.php
+++ b/src/tag/CompoundTag.php
@@ -29,7 +29,6 @@ use pocketmine\nbt\NbtStreamWriter;
 use pocketmine\nbt\NoSuchTagException;
 use pocketmine\nbt\ReaderTracker;
 use pocketmine\nbt\UnexpectedTagTypeException;
-use pocketmine\utils\Limits;
 use function count;
 use function func_num_args;
 use function get_class;
@@ -118,8 +117,8 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @return $this
 	 */
 	public function setTag(string $name, Tag $tag) : self{
-		if(strlen($name) > Limits::INT16_MAX){
-			throw new \InvalidArgumentException(sprintf("Tag name must be at most %d bytes, but got %d bytes", Limits::INT16_MAX, strlen($name)));
+		if(strlen($name) > NBT::MAX_STRING_LENGTH){
+			throw new \InvalidArgumentException(sprintf("Tag name must be at most %d bytes, but got %d bytes", NBT::MAX_STRING_LENGTH, strlen($name)));
 		}
 		$this->value[$name] = $tag;
 		return $this;

--- a/src/tag/FloatTag.php
+++ b/src/tag/FloatTag.php
@@ -26,7 +26,6 @@ namespace pocketmine\nbt\tag;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\NbtStreamReader;
 use pocketmine\nbt\NbtStreamWriter;
-use pocketmine\utils\Binary;
 use function func_num_args;
 
 final class FloatTag extends ImmutableTag{
@@ -66,6 +65,6 @@ final class FloatTag extends ImmutableTag{
 		//the values of TAG_Float are represented in 32 bits (single precision), so we don't want extra precision given
 		//by 64-bit in-memory representation to break comparison (e.g. 0.3 != decode(encode(0.3)))
 		//this intentionally truncates our value so that it compares as valid
-		return $that instanceof $this && Binary::writeFloat($this->value) === Binary::writeFloat($that->value);
+		return $that instanceof $this && pack("G", $this->value) === pack("G", $that->value);
 	}
 }

--- a/src/tag/FloatTag.php
+++ b/src/tag/FloatTag.php
@@ -27,6 +27,7 @@ use pocketmine\nbt\NBT;
 use pocketmine\nbt\NbtStreamReader;
 use pocketmine\nbt\NbtStreamWriter;
 use function func_num_args;
+use function pack;
 
 final class FloatTag extends ImmutableTag{
 	/** @var float */

--- a/src/tag/FloatTag.php
+++ b/src/tag/FloatTag.php
@@ -23,11 +23,11 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt\tag;
 
+use pmmp\encoding\LE;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\NbtStreamReader;
 use pocketmine\nbt\NbtStreamWriter;
 use function func_num_args;
-use function pack;
 
 final class FloatTag extends ImmutableTag{
 	/** @var float */
@@ -66,6 +66,6 @@ final class FloatTag extends ImmutableTag{
 		//the values of TAG_Float are represented in 32 bits (single precision), so we don't want extra precision given
 		//by 64-bit in-memory representation to break comparison (e.g. 0.3 != decode(encode(0.3)))
 		//this intentionally truncates our value so that it compares as valid
-		return $that instanceof $this && pack("G", $this->value) === pack("G", $that->value);
+		return $that instanceof $this && LE::packFloat($this->value) === LE::packFloat($that->value);
 	}
 }

--- a/src/tag/StringTag.php
+++ b/src/tag/StringTag.php
@@ -36,8 +36,8 @@ final class StringTag extends ImmutableTag{
 
 	public function __construct(string $value){
 		self::restrictArgCount(__METHOD__, func_num_args(), 1);
-		if(strlen($value) > 32767){
-			throw new InvalidTagValueException("StringTag cannot hold more than 32767 bytes, got string of length " . strlen($value));
+		if(strlen($value) > NBT::MAX_STRING_LENGTH){
+			throw new InvalidTagValueException("StringTag cannot hold more than " . NBT::MAX_STRING_LENGTH . " bytes, got string of length " . strlen($value));
 		}
 		$this->value = $value;
 	}

--- a/tests/phpunit/NbtSerializerTest.php
+++ b/tests/phpunit/NbtSerializerTest.php
@@ -80,7 +80,7 @@ class NbtSerializerTest extends TestCase{
 		$tag = new IntTag(123);
 		$serializer = new BigEndianNbtSerializer();
 		$raw = $serializer->writeHeadless($tag);
-		self::assertSame($raw, Binary::writeInt(123));
+		self::assertSame($raw, pack("N", 123));
 
 		$tag2 = $serializer->readHeadless($raw, NBT::TAG_Int);
 		self::assertEquals($tag, $tag2);

--- a/tests/phpunit/NbtSerializerTest.php
+++ b/tests/phpunit/NbtSerializerTest.php
@@ -27,7 +27,6 @@ use PHPUnit\Framework\TestCase;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ListTag;
-use pocketmine\utils\Binary;
 
 class NbtSerializerTest extends TestCase{
 

--- a/tests/phpunit/TreeRootTest.php
+++ b/tests/phpunit/TreeRootTest.php
@@ -4,15 +4,14 @@ namespace pocketmine\nbt;
 
 use PHPUnit\Framework\TestCase;
 use pocketmine\nbt\tag\IntTag;
-use pocketmine\utils\Limits;
 use function str_repeat;
 
 class TreeRootTest extends TestCase{
 
 	public function testNameLength() : void{
-		new TreeRoot(new IntTag(1), str_repeat(".", Limits::INT16_MAX)); //ok
+		new TreeRoot(new IntTag(1), str_repeat(".", NBT::MAX_STRING_LENGTH)); //ok
 
 		$this->expectException(\InvalidArgumentException::class);
-		new TreeRoot(new IntTag(1), str_repeat(".", Limits::INT16_MAX + 1)); //error
+		new TreeRoot(new IntTag(1), str_repeat(".", NBT::MAX_STRING_LENGTH + 1)); //error
 	}
 }

--- a/tests/phpunit/tag/CompoundTagTest.php
+++ b/tests/phpunit/tag/CompoundTagTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use PHPUnit\Framework\TestCase;
-use pocketmine\utils\Limits;
+use pocketmine\nbt\NBT;
 use function array_fill;
 use function str_repeat;
 
@@ -187,10 +187,10 @@ class CompoundTagTest extends TestCase{
 
 	public function testNameLength() : void{
 		$tag = CompoundTag::create();
-		$tag->setTag(str_repeat(".", Limits::INT16_MAX), new IntTag(1)); //ok
+		$tag->setTag(str_repeat(".", NBT::MAX_STRING_LENGTH), new IntTag(1)); //ok
 
 		$this->expectException(\InvalidArgumentException::class);
-		$tag->setTag(str_repeat(".", Limits::INT16_MAX + 1), new IntTag(1)); //error
+		$tag->setTag(str_repeat(".", NBT::MAX_STRING_LENGTH + 1), new IntTag(1)); //error
 	}
 
 	//TODO: add more tests


### PR DESCRIPTION
in very brief tests, this yielded significant performance improvements, on the order of 2x for encoding and 1.5x for decoding.

This doesn't change any public API, but inheritors of `BaseNbtSerializer` will need to be updated to use this. In practice nothing except `NetworkNbtSerializer` in BedrockProtocol should be affected.