### PR TITLE
Fix return-type issue

### DIFF
--- a/src/tag/CompoundTag.php
+++ b/src/tag/CompoundTag.php
@@ -163,35 +163,35 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * The following methods are wrappers around getTagValue() with type safety.
 	 */
 
-	public function getByte(string $name, ?int $default = null) : int{
+	public function getByte(string $name, ?int $default = null) : ?int{
 		return $this->getTagValue($name, ByteTag::class, $default);
 	}
 
-	public function getShort(string $name, ?int $default = null) : int{
+	public function getShort(string $name, ?int $default = null) : ?int{
 		return $this->getTagValue($name, ShortTag::class, $default);
 	}
 
-	public function getInt(string $name, ?int $default = null) : int{
+	public function getInt(string $name, ?int $default = null) : ?int{
 		return $this->getTagValue($name, IntTag::class, $default);
 	}
 
-	public function getLong(string $name, ?int $default = null) : int{
+	public function getLong(string $name, ?int $default = null) : ?int{
 		return $this->getTagValue($name, LongTag::class, $default);
 	}
 
-	public function getFloat(string $name, ?float $default = null) : float{
+	public function getFloat(string $name, ?float $default = null) : ?float{
 		return $this->getTagValue($name, FloatTag::class, $default);
 	}
 
-	public function getDouble(string $name, ?float $default = null) : float{
+	public function getDouble(string $name, ?float $default = null) : ?float{
 		return $this->getTagValue($name, DoubleTag::class, $default);
 	}
 
-	public function getByteArray(string $name, ?string $default = null) : string{
+	public function getByteArray(string $name, ?string $default = null) : ?string{
 		return $this->getTagValue($name, ByteArrayTag::class, $default);
 	}
 
-	public function getString(string $name, ?string $default = null) : string{
+	public function getString(string $name, ?string $default = null) : ?string{
 		return $this->getTagValue($name, StringTag::class, $default);
 	}
 
@@ -200,7 +200,7 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 *
 	 * @return int[]
 	 */
-	public function getIntArray(string $name, ?array $default = null) : array{
+	public function getIntArray(string $name, ?array $default = null) : ?array{
 		return $this->getTagValue($name, IntArrayTag::class, $default);
 	}
 


### PR DESCRIPTION
This commit resolves the issue where the default argument could be null, while the return type was not nullable. This mismatch could lead to exceptions during usage and when returning null.