### PR TITLE
Store immutable tags internally as plain values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php }}
     steps:
     - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP library for working with Named Binary Tags",
     "type": "library",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "php-64bit": "*",
         "pocketmine/binaryutils": "^0.2.0"
     },

--- a/src/BaseNbtSerializer.php
+++ b/src/BaseNbtSerializer.php
@@ -51,7 +51,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 		}
 
 		$rootName = $this->readString();
-		return new TreeRoot(NBT::createTag($type, $this, new ReaderTracker($maxDepth)), $rootName);
+		return new TreeRoot(NBT::boxValue($type, NBT::readValue($type, $this, new ReaderTracker($maxDepth))), $rootName);
 	}
 
 	/**
@@ -87,7 +87,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	public function readHeadless(string $buffer, int $rootType, int &$offset = 0, int $maxDepth = 0) : Tag{
 		$this->buffer = new BinaryStream($buffer, $offset);
 
-		$data = NBT::createTag($rootType, $this, new ReaderTracker($maxDepth));
+		$data = NBT::boxValue($rootType, NBT::readValue($rootType, $this, new ReaderTracker($maxDepth)));
 		$offset = $this->buffer->getOffset();
 
 		return $data;
@@ -119,9 +119,12 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	}
 
 	private function writeRoot(TreeRoot $root) : void{
-		$this->writeByte($root->getTag()->getType());
+		$tag = $root->getTag();
+		$type = $tag->getType();
+
+		$this->writeByte($type);
 		$this->writeString($root->getName());
-		$root->getTag()->write($this);
+		NBT::writeValue($type, NBT::unboxValue($tag), $this);
 	}
 
 	public function write(TreeRoot $data) : string{
@@ -140,7 +143,7 @@ abstract class BaseNbtSerializer implements NbtStreamReader, NbtStreamWriter{
 	 */
 	public function writeHeadless(Tag $data) : string{
 		$this->buffer = new BinaryStream();
-		$data->write($this);
+		NBT::writeValue($data->getType(), NBT::unboxValue($data), $this);
 		return $this->buffer->getBuffer();
 	}
 

--- a/src/NBT.php
+++ b/src/NBT.php
@@ -38,10 +38,6 @@ use pocketmine\nbt\tag\LongTag;
 use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\nbt\tag\Tag;
-use function is_array;
-use function is_float;
-use function is_int;
-use function is_string;
 
 abstract class NBT{
 
@@ -79,59 +75,66 @@ abstract class NBT{
 		};
 	}
 
+	private static function assumeInt(mixed $value) : int{
+		/** @var int $value */
+		return $value;
+	}
+
+	private static function assumeFloat(mixed $value) : float{
+		/** @var float $value */
+		return $value;
+	}
+
+	private static function assumeString(mixed $value) : string{
+		/** @var string $value */
+		return $value;
+	}
+
+	/**
+	 * @return int[]
+	 * @phpstan-return list<int>
+	 */
+	private static function assumeListInt(mixed $value) : array{
+		/**
+		 * @var int[] $value
+		 * @phpstan-var list<int> $value
+		 */
+		return $value;
+	}
+
 	public static function writeValue(int $type, mixed $value, NbtStreamWriter $writer) : void{
 		match (true) {
-			is_int($value) => match ($type) {
-				self::TAG_Byte => $writer->writeByte($value),
-				self::TAG_Short => $writer->writeShort($value),
-				self::TAG_Int => $writer->writeInt($value),
-				self::TAG_Long => $writer->writeLong($value),
-				default => throw new \LogicException("Didn't expect an int value for tag type $type"),
-			},
-			is_float($value) => match ($type) {
-				self::TAG_Float => $writer->writeFloat($value),
-				self::TAG_Double => $writer->writeDouble($value),
-				default => throw new \LogicException("Didn't expect a float value for tag type $type"),
-			},
-			is_string($value) => match ($type) {
-				self::TAG_ByteArray => $writer->writeByteArray($value),
-				self::TAG_String => $writer->writeString($value),
-				default => throw new \LogicException("Didn't expect a string value for tag type $type"),
-			},
-			is_array($value) => match ($type) {
-				self::TAG_IntArray => $writer->writeIntArray($value),
-				default => throw new \LogicException("Didn't expect an array value for tag type $type"),
-			},
 			$value instanceof CompoundTag || $value instanceof ListTag => $value->write($writer),
-			default => throw new \LogicException("Invalid tag type $type"),
+			default => match ($type) {
+				self::TAG_Byte => $writer->writeByte(self::assumeInt($value)),
+				self::TAG_Short => $writer->writeShort(self::assumeInt($value)),
+				self::TAG_Int => $writer->writeInt(self::assumeInt($value)),
+				self::TAG_Long => $writer->writeLong(self::assumeInt($value)),
+				self::TAG_Float => $writer->writeFloat(self::assumeFloat($value)),
+				self::TAG_Double => $writer->writeDouble(self::assumeFloat($value)),
+				self::TAG_ByteArray => $writer->writeByteArray(self::assumeString($value)),
+				self::TAG_String => $writer->writeString(self::assumeString($value)),
+				self::TAG_IntArray => $writer->writeIntArray(self::assumeListInt($value)),
+				default => throw new \LogicException("Invalid tag type $type"),
+			},
 		};
 	}
 
 	public static function boxValue(int $type, mixed $value) : Tag{
 		return match (true) {
-			is_int($value) => match ($type) {
-				self::TAG_Byte => new ByteTag($value),
-				self::TAG_Short => new ShortTag($value),
-				self::TAG_Int => new IntTag($value),
-				self::TAG_Long => new LongTag($value),
-				default => throw new \LogicException("Didn't expect an int value for tag type $type"),
-			},
-			is_float($value) => match ($type) {
-				self::TAG_Float => new FloatTag($value),
-				self::TAG_Double => new DoubleTag($value),
-				default => throw new \LogicException("Didn't expect a float value for tag type $type"),
-			},
-			is_string($value) => match ($type) {
-				self::TAG_ByteArray => new ByteArrayTag($value),
-				self::TAG_String => new StringTag($value),
-				default => throw new \LogicException("Didn't expect a string value for tag type $type"),
-			},
-			is_array($value) => match ($type) {
-				self::TAG_IntArray => new IntArrayTag($value),
-				default => throw new \LogicException("Didn't expect an array value for tag type $type"),
-			},
 			$value instanceof CompoundTag || $value instanceof ListTag => $value,
-			default => throw new \LogicException("Invalid tag type $type"),
+			default => match ($type) {
+				self::TAG_Byte => new ByteTag(self::assumeInt($value)),
+				self::TAG_Short => new ShortTag(self::assumeInt($value)),
+				self::TAG_Int => new IntTag(self::assumeInt($value)),
+				self::TAG_Long => new LongTag(self::assumeInt($value)),
+				self::TAG_Float => new FloatTag(self::assumeFloat($value)),
+				self::TAG_Double => new DoubleTag(self::assumeFloat($value)),
+				self::TAG_ByteArray => new ByteArrayTag(self::assumeString($value)),
+				self::TAG_String => new StringTag(self::assumeString($value)),
+				self::TAG_IntArray => new IntArrayTag(self::assumeListInt($value)),
+				default => throw new \LogicException("Invalid tag type $type"),
+			},
 		};
 	}
 

--- a/src/NBT.php
+++ b/src/NBT.php
@@ -103,9 +103,10 @@ abstract class NBT{
 	}
 
 	public static function writeValue(int $type, mixed $value, NbtStreamWriter $writer) : void{
-		match (true) {
-			$value instanceof CompoundTag || $value instanceof ListTag => $value->write($writer),
-			default => match ($type) {
+		if($value instanceof CompoundTag || $value instanceof ListTag){
+			$value->write($writer);
+		}else{
+			match ($type) {
 				self::TAG_Byte => $writer->writeByte(self::assumeInt($value)),
 				self::TAG_Short => $writer->writeShort(self::assumeInt($value)),
 				self::TAG_Int => $writer->writeInt(self::assumeInt($value)),
@@ -115,26 +116,27 @@ abstract class NBT{
 				self::TAG_ByteArray => $writer->writeByteArray(self::assumeString($value)),
 				self::TAG_String => $writer->writeString(self::assumeString($value)),
 				self::TAG_IntArray => $writer->writeIntArray(self::assumeListInt($value)),
-				default => throw new \LogicException("Invalid tag type $type"),
-			},
-		};
+				default => throw new \LogicException("Unexpected unboxed tag type $type"),
+			};
+		}
 	}
 
 	public static function boxValue(int $type, mixed $value) : Tag{
-		return match (true) {
-			$value instanceof CompoundTag || $value instanceof ListTag => $value,
-			default => match ($type) {
-				self::TAG_Byte => new ByteTag(self::assumeInt($value)),
-				self::TAG_Short => new ShortTag(self::assumeInt($value)),
-				self::TAG_Int => new IntTag(self::assumeInt($value)),
-				self::TAG_Long => new LongTag(self::assumeInt($value)),
-				self::TAG_Float => new FloatTag(self::assumeFloat($value)),
-				self::TAG_Double => new DoubleTag(self::assumeFloat($value)),
-				self::TAG_ByteArray => new ByteArrayTag(self::assumeString($value)),
-				self::TAG_String => new StringTag(self::assumeString($value)),
-				self::TAG_IntArray => new IntArrayTag(self::assumeListInt($value)),
-				default => throw new \LogicException("Invalid tag type $type"),
-			},
+		if($value instanceof CompoundTag || $value instanceof IntTag){
+			return $value;
+		}
+
+		return match ($type) {
+			self::TAG_Byte => new ByteTag(self::assumeInt($value)),
+			self::TAG_Short => new ShortTag(self::assumeInt($value)),
+			self::TAG_Int => new IntTag(self::assumeInt($value)),
+			self::TAG_Long => new LongTag(self::assumeInt($value)),
+			self::TAG_Float => new FloatTag(self::assumeFloat($value)),
+			self::TAG_Double => new DoubleTag(self::assumeFloat($value)),
+			self::TAG_ByteArray => new ByteArrayTag(self::assumeString($value)),
+			self::TAG_String => new StringTag(self::assumeString($value)),
+			self::TAG_IntArray => new IntArrayTag(self::assumeListInt($value)),
+			default => throw new \LogicException("Unexpected unboxed tag type $type"),
 		};
 	}
 

--- a/src/NBT.php
+++ b/src/NBT.php
@@ -122,7 +122,7 @@ abstract class NBT{
 	}
 
 	public static function boxValue(int $type, mixed $value) : Tag{
-		if($value instanceof CompoundTag || $value instanceof IntTag){
+		if($value instanceof CompoundTag || $value instanceof ListTag){
 			return $value;
 		}
 

--- a/src/NBT.php
+++ b/src/NBT.php
@@ -38,6 +38,10 @@ use pocketmine\nbt\tag\LongTag;
 use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\nbt\tag\Tag;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_string;
 
 abstract class NBT{
 
@@ -55,34 +59,100 @@ abstract class NBT{
 	public const TAG_IntArray = 11;
 
 	/**
+	 * @return mixed
 	 * @throws NbtDataException
 	 */
-	public static function createTag(int $type, NbtStreamReader $reader, ReaderTracker $tracker) : Tag{
-		switch($type){
-			case self::TAG_Byte:
-				return ByteTag::read($reader);
-			case self::TAG_Short:
-				return ShortTag::read($reader);
-			case self::TAG_Int:
-				return IntTag::read($reader);
-			case self::TAG_Long:
-				return LongTag::read($reader);
-			case self::TAG_Float:
-				return FloatTag::read($reader);
-			case self::TAG_Double:
-				return DoubleTag::read($reader);
-			case self::TAG_ByteArray:
-				return ByteArrayTag::read($reader);
-			case self::TAG_String:
-				return StringTag::read($reader);
-			case self::TAG_List:
-				return ListTag::read($reader, $tracker);
-			case self::TAG_Compound:
-				return CompoundTag::read($reader, $tracker);
-			case self::TAG_IntArray:
-				return IntArrayTag::read($reader);
-			default:
-				throw new NbtDataException("Unknown NBT tag type $type");
-		}
+	public static function readValue(int $type, NbtStreamReader $reader, ReaderTracker $tracker){
+		return match ($type) {
+			self::TAG_Byte => $reader->readSignedByte(),
+			self::TAG_Short => $reader->readSignedShort(),
+			self::TAG_Int => $reader->readInt(),
+			self::TAG_Long => $reader->readLong(),
+			self::TAG_Float => $reader->readFloat(),
+			self::TAG_Double => $reader->readDouble(),
+			self::TAG_ByteArray => $reader->readByteArray(),
+			self::TAG_String => $reader->readString(),
+			self::TAG_List => ListTag::read($reader, $tracker),
+			self::TAG_Compound => CompoundTag::read($reader, $tracker),
+			self::TAG_IntArray => $reader->readIntArray(),
+			default => throw new \LogicException("Invalid tag type $type"),
+		};
+	}
+
+	public static function writeValue(int $type, mixed $value, NbtStreamWriter $writer) : void{
+		match (true) {
+			is_int($value) => match ($type) {
+				self::TAG_Byte => $writer->writeByte($value),
+				self::TAG_Short => $writer->writeShort($value),
+				self::TAG_Int => $writer->writeInt($value),
+				self::TAG_Long => $writer->writeLong($value),
+				default => throw new \LogicException("Didn't expect an int value for tag type $type"),
+			},
+			is_float($value) => match ($type) {
+				self::TAG_Float => $writer->writeFloat($value),
+				self::TAG_Double => $writer->writeDouble($value),
+				default => throw new \LogicException("Didn't expect a float value for tag type $type"),
+			},
+			is_string($value) => match ($type) {
+				self::TAG_ByteArray => $writer->writeByteArray($value),
+				self::TAG_String => $writer->writeString($value),
+				default => throw new \LogicException("Didn't expect a string value for tag type $type"),
+			},
+			is_array($value) => match ($type) {
+				self::TAG_IntArray => $writer->writeIntArray($value),
+				default => throw new \LogicException("Didn't expect an array value for tag type $type"),
+			},
+			$value instanceof CompoundTag || $value instanceof ListTag => $value->write($writer),
+			default => throw new \LogicException("Invalid tag type $type"),
+		};
+	}
+
+	public static function boxValue(int $type, mixed $value) : Tag{
+		return match (true) {
+			is_int($value) => match ($type) {
+				self::TAG_Byte => new ByteTag($value),
+				self::TAG_Short => new ShortTag($value),
+				self::TAG_Int => new IntTag($value),
+				self::TAG_Long => new LongTag($value),
+				default => throw new \LogicException("Didn't expect an int value for tag type $type"),
+			},
+			is_float($value) => match ($type) {
+				self::TAG_Float => new FloatTag($value),
+				self::TAG_Double => new DoubleTag($value),
+				default => throw new \LogicException("Didn't expect a float value for tag type $type"),
+			},
+			is_string($value) => match ($type) {
+				self::TAG_ByteArray => new ByteArrayTag($value),
+				self::TAG_String => new StringTag($value),
+				default => throw new \LogicException("Didn't expect a string value for tag type $type"),
+			},
+			is_array($value) => match ($type) {
+				self::TAG_IntArray => new IntArrayTag($value),
+				default => throw new \LogicException("Didn't expect an array value for tag type $type"),
+			},
+			$value instanceof CompoundTag || $value instanceof ListTag => $value,
+			default => throw new \LogicException("Invalid tag type $type"),
+		};
+	}
+
+	public static function unboxValue(Tag $tag) : mixed{
+		return $tag instanceof CompoundTag || $tag instanceof ListTag ? $tag : $tag->getValue();
+	}
+
+	public static function getClass(int $type) : string{
+		return match ($type) {
+			self::TAG_Byte => ByteTag::class,
+			self::TAG_Short => ShortTag::class,
+			self::TAG_Int => IntTag::class,
+			self::TAG_Long => LongTag::class,
+			self::TAG_Float => FloatTag::class,
+			self::TAG_Double => DoubleTag::class,
+			self::TAG_ByteArray => ByteArrayTag::class,
+			self::TAG_String => StringTag::class,
+			self::TAG_List => ListTag::class,
+			self::TAG_Compound => CompoundTag::class,
+			self::TAG_IntArray => IntArrayTag::class,
+			default => throw new \LogicException("Invalid tag type $type"),
+		};
 	}
 }

--- a/src/tag/ByteArrayTag.php
+++ b/src/tag/ByteArrayTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 use function base64_encode;
 use function func_num_args;
 
@@ -44,14 +42,6 @@ final class ByteArrayTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_ByteArray;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readByteArray());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeByteArray($this->value);
 	}
 
 	public function getValue() : string{

--- a/src/tag/ByteTag.php
+++ b/src/tag/ByteTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 
 final class ByteTag extends ImmutableTag{
 	use IntegerishTagTrait;
@@ -40,13 +38,5 @@ final class ByteTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_Byte;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readSignedByte());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeByte($this->value);
 	}
 }

--- a/src/tag/CompoundTag.php
+++ b/src/tag/CompoundTag.php
@@ -42,8 +42,17 @@ use function strval;
 final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	use NoDynamicFieldsTrait;
 
-	/** @var Tag[] */
-	private $value = [];
+	/**
+	 * @var int[]
+	 * @phpstan-var array<string, int>
+	 */
+	private array $valueTypes = [];
+
+	/**
+	 * @var mixed[]
+	 * @phpstan-var array<string, mixed>
+	 */
+	private array $value = [];
 
 	public function __construct(){
 		self::restrictArgCount(__METHOD__, func_num_args(), 0);
@@ -71,7 +80,11 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @return Tag[]
 	 */
 	public function getValue(){
-		return $this->value;
+		$result = [];
+		foreach($this->value as $name => $value){
+			$result[$name] = NBT::boxValue($this->valueTypes[$name], $value);
+		}
+		return $result;
 	}
 
 	/*
@@ -82,7 +95,8 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * Returns the tag with the specified name, or null if it does not exist.
 	 */
 	public function getTag(string $name) : ?Tag{
-		return $this->value[$name] ?? null;
+		$value = $this->value[$name] ?? null;
+		return $value !== null ? NBT::boxValue($this->valueTypes[$name], $value) : null;
 	}
 
 	/**
@@ -115,7 +129,9 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @return $this
 	 */
 	public function setTag(string $name, Tag $tag) : self{
-		$this->value[$name] = $tag;
+		$this->valueTypes[$name] = $tag->getType();
+		$this->value[$name] = NBT::unboxValue($tag);
+
 		return $this;
 	}
 
@@ -126,6 +142,7 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	public function removeTag(string ...$names) : void{
 		foreach($names as $name){
 			unset($this->value[$name]);
+			unset($this->valueTypes[$name]);
 		}
 	}
 
@@ -144,19 +161,17 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @throws NoSuchTagException
 	 */
 	private function getTagValue(string $name, string $expectedClass, $default = null){
-		$tag = $this->getTag($name);
-		if($tag instanceof $expectedClass){
-			return $tag->getValue();
+		if(!isset($this->value[$name])){
+			if($default === null){
+				throw new NoSuchTagException("Tag \"$name\" does not exist");
+			}
+			return $default;
 		}
-		if($tag !== null){
-			throw new UnexpectedTagTypeException("Expected a tag of type $expectedClass, got " . get_class($tag));
+		$actualClass = NBT::getClass($this->valueTypes[$name]);
+		if($expectedClass !== $actualClass){
+			throw new UnexpectedTagTypeException("Expected a tag of type $expectedClass, got $actualClass");
 		}
-
-		if($default === null){
-			throw new NoSuchTagException("Tag \"$name\" does not exist");
-		}
-
-		return $default;
+		return $this->value[$name];
 	}
 
 	/*
@@ -204,6 +219,18 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 		return $this->getTagValue($name, IntArrayTag::class, $default);
 	}
 
+	/**
+	 * @param mixed $value
+	 *
+	 * @return $this
+	 */
+	private function setTagValue(string $name, int $type, $value) : self{
+		$this->valueTypes[$name] = $type;
+		$this->value[$name] = $value;
+
+		return $this;
+	}
+
 	/*
 	 * The following methods are wrappers around setTag() which create appropriate tag objects on the fly.
 	 */
@@ -212,56 +239,56 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @return $this
 	 */
 	public function setByte(string $name, int $value) : self{
-		return $this->setTag($name, new ByteTag($value));
+		return $this->setTagValue($name, NBT::TAG_Byte, $value);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function setShort(string $name, int $value) : self{
-		return $this->setTag($name, new ShortTag($value));
+		return $this->setTagValue($name, NBT::TAG_Short, $value);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function setInt(string $name, int $value) : self{
-		return $this->setTag($name, new IntTag($value));
+		return $this->setTagValue($name, NBT::TAG_Int, $value);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function setLong(string $name, int $value) : self{
-		return $this->setTag($name, new LongTag($value));
+		return $this->setTagValue($name, NBT::TAG_Long, $value);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function setFloat(string $name, float $value) : self{
-		return $this->setTag($name, new FloatTag($value));
+		return $this->setTagValue($name, NBT::TAG_Float, $value);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function setDouble(string $name, float $value) : self{
-		return $this->setTag($name, new DoubleTag($value));
+		return $this->setTagValue($name, NBT::TAG_Double, $value);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function setByteArray(string $name, string $value) : self{
-		return $this->setTag($name, new ByteArrayTag($value));
+		return $this->setTagValue($name, NBT::TAG_ByteArray, $value);
 	}
 
 	/**
 	 * @return $this
 	 */
 	public function setString(string $name, string $value) : self{
-		return $this->setTag($name, new StringTag($value));
+		return $this->setTagValue($name, NBT::TAG_String, $value);
 	}
 
 	/**
@@ -271,7 +298,7 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @return $this
 	 */
 	public function setIntArray(string $name, array $value) : self{
-		return $this->setTag($name, new IntArrayTag($value));
+		return $this->setTagValue($name, NBT::TAG_IntArray, $value);
 	}
 
 	protected function getTypeName() : string{
@@ -287,8 +314,9 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 		$tracker->protectDepth(static function() use($reader, $tracker, $result) : void{
 			for($type = $reader->readByte(); $type !== NBT::TAG_End; $type = $reader->readByte()){
 				$name = $reader->readString();
-				$tag = NBT::createTag($type, $reader, $tracker);
-				if($result->getTag($name) !== null){
+				$value = NBT::readValue($type, $reader, $tracker);
+
+				if(isset($result->value[$name])){
 					//this is technically a corruption case, but it's very common on older PM worlds (pretty much every
 					//furnace in PM worlds prior to 2017 is affected), and since we can't extricate this borked data
 					//from the rest in Anvil/McRegion worlds, we can't barf on this - it would result in complete loss
@@ -296,22 +324,23 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 					//TODO: add a flag to enable throwing on this (strict mode)
 					continue;
 				}
-				$result->setTag($name, $tag);
+				$result->setTagValue($name, $type, $value);
 			}
 		});
 		return $result;
 	}
 
 	public function write(NbtStreamWriter $writer) : void{
-		foreach($this->value as $name => $tag){
+		foreach($this->value as $name => $value){
 			if(is_int($name)){
 				//PHP sucks
 				//we only cast on seeing an int, because forcibly casting other types might conceal bugs.
 				$name = (string) $name;
 			}
-			$writer->writeByte($tag->getType());
+			$type = $this->valueTypes[$name];
+			$writer->writeByte($type);
 			$writer->writeString($name);
-			$tag->write($writer);
+			NBT::writeValue($type, $value, $writer);
 		}
 		$writer->writeByte(NBT::TAG_End);
 	}
@@ -319,14 +348,16 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	protected function stringifyValue(int $indentation) : string{
 		$str = "{\n";
 		foreach($this->value as $name => $tag){
-			$str .= str_repeat("  ", $indentation + 1) . "\"$name\" => " . $tag->toString($indentation + 1) . "\n";
+			$str .= str_repeat("  ", $indentation + 1) . "\"$name\" => " . NBT::boxValue($this->valueTypes[$name], $tag)->toString($indentation + 1) . "\n";
 		}
 		return $str . str_repeat("  ", $indentation) . "}";
 	}
 
 	public function __clone(){
-		foreach($this->value as $key => $tag){
-			$this->value[$key] = $tag->safeClone();
+		foreach($this->value as $name => $value){
+			if($value instanceof Tag){
+				$this->value[$name] = $value->safeClone();
+			}
 		}
 	}
 
@@ -339,21 +370,22 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @phpstan-return \Generator<string, Tag, void, void>
 	 */
 	public function getIterator() : \Generator{
-		foreach($this->value as $name => $tag){
+		foreach($this->value as $name => $value){
 			// PHP arrays are idiotic and cast keys like "1" to int(1)
 			// this also stops us using "yield from". REEEEEEEEEE
-			yield strval($name) => $tag;
+			yield strval($name) => NBT::boxValue($this->valueTypes[$name], $value);
 		}
 	}
 
 	public function equals(Tag $that) : bool{
-		if(!($that instanceof $this) or count($this->value) !== count($that->value)){
+		if(!($that instanceof $this) or $this->valueTypes !== $that->valueTypes){
 			return false;
 		}
 
-		foreach($this->value as $k => $v){
-			$other = $that->value[$k] ?? null;
-			if($other === null or !$v->equals($other)){
+		foreach($this->value as $name => $value){
+			$thatValue = $that->value[$name];
+
+			if($value !== $thatValue && (!$value instanceof Tag || !$thatValue instanceof Tag || !$value->equals($thatValue))){
 				return false;
 			}
 		}
@@ -370,8 +402,9 @@ final class CompoundTag extends Tag implements \Countable, \IteratorAggregate{
 	public function merge(CompoundTag $other) : CompoundTag{
 		$new = clone $this;
 
-		foreach($other as $k => $namedTag){
-			$new->setTag($k, clone $namedTag);
+		foreach($other->value as $name => $value){
+			$new->valueTypes[$name] = $other->valueTypes[$name];
+			$new->value[$name] = $value instanceof Tag ? clone $value : $value;
 		}
 
 		return $new;

--- a/src/tag/DoubleTag.php
+++ b/src/tag/DoubleTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 use function func_num_args;
 
 final class DoubleTag extends ImmutableTag{
@@ -43,14 +41,6 @@ final class DoubleTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_Double;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readDouble());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeDouble($this->value);
 	}
 
 	public function getValue() : float{

--- a/src/tag/FloatTag.php
+++ b/src/tag/FloatTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 use pocketmine\utils\Binary;
 use function func_num_args;
 
@@ -44,14 +42,6 @@ final class FloatTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_Float;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readFloat());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeFloat($this->value);
 	}
 
 	public function getValue() : float{

--- a/src/tag/IntArrayTag.php
+++ b/src/tag/IntArrayTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 use function array_values;
 use function assert;
 use function func_num_args;
@@ -64,14 +62,6 @@ final class IntArrayTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_IntArray;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readIntArray());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeIntArray($this->value);
 	}
 
 	protected function stringifyValue(int $indentation) : string{

--- a/src/tag/IntTag.php
+++ b/src/tag/IntTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 
 final class IntTag extends ImmutableTag{
 	use IntegerishTagTrait;
@@ -42,13 +40,5 @@ final class IntTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_Int;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readInt());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeInt($this->value);
 	}
 }

--- a/src/tag/ListTag.php
+++ b/src/tag/ListTag.php
@@ -50,8 +50,8 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 	/** @var int */
 	private $tagType;
 	/**
-	 * @var Tag[]
-	 * @phpstan-var list<Tag>
+	 * @var mixed[]
+	 * @phpstan-var list<mixed>
 	 */
 	private $value = [];
 
@@ -71,7 +71,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @phpstan-return list<Tag>
 	 */
 	public function getValue() : array{
-		return $this->value;
+		return array_map(fn(mixed $value) => NBT::boxValue($this->tagType, $value), $this->value);
 	}
 
 	/**
@@ -80,7 +80,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @phpstan-return list<mixed>
 	 */
 	public function getAllValues() : array{
-		return array_map(fn(Tag $t) => $t->getValue(), $this->value);
+		return array_map(fn(mixed $t) => $t instanceof Tag ? $t->getValue() : $t, $this->value);
 	}
 
 	public function count() : int{
@@ -96,7 +96,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 	 */
 	public function push(Tag $tag) : void{
 		$this->checkTagType($tag);
-		$this->value[] = $tag;
+		$this->value[] = NBT::unboxValue($tag);
 	}
 
 	/**
@@ -106,7 +106,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 		if(count($this->value) === 0){
 			throw new \LogicException("List is empty");
 		}
-		return array_pop($this->value);
+		return NBT::boxValue($this->tagType, array_pop($this->value));
 	}
 
 	/**
@@ -114,7 +114,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 	 */
 	public function unshift(Tag $tag) : void{
 		$this->checkTagType($tag);
-		array_unshift($this->value, $tag);
+		array_unshift($this->value, NBT::unboxValue($tag));
 	}
 
 	/**
@@ -124,7 +124,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 		if(count($this->value) === 0){
 			throw new \LogicException("List is empty");
 		}
-		return array_shift($this->value);
+		return NBT::boxValue($this->tagType, array_shift($this->value));
 	}
 
 	/**
@@ -140,7 +140,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 			throw new \OutOfRangeException("Offset cannot be negative or larger than the list's current size");
 		}
 		$newValue = array_slice($this->value, 0, $offset);
-		$newValue[] = $tag;
+		$newValue[] = NBT::unboxValue($tag);
 		array_push($newValue, ...array_slice($this->value, $offset));
 		$this->value = $newValue;
 	}
@@ -164,7 +164,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 		if(!isset($this->value[$offset])){
 			throw new \OutOfRangeException("No such tag at offset $offset");
 		}
-		return $this->value[$offset];
+		return NBT::boxValue($this->tagType, $this->value[$offset]);
 	}
 
 	/**
@@ -174,7 +174,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 		if(count($this->value) === 0){
 			throw new \LogicException("List is empty");
 		}
-		return $this->value[0];
+		return NBT::boxValue($this->tagType, $this->value[0]);
 	}
 
 	/**
@@ -184,7 +184,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 		if(count($this->value) === 0){
 			throw new \LogicException("List is empty");
 		}
-		return $this->value[array_key_last($this->value)];
+		return NBT::boxValue($this->tagType, $this->value[array_key_last($this->value)]);
 	}
 
 	/**
@@ -197,7 +197,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 		if($offset < 0 || $offset > count($this->value)){ //allow setting the end offset
 			throw new \OutOfRangeException("Offset cannot be negative or larger than the list's current size");
 		}
-		$this->value[$offset] = $tag;
+		$this->value[$offset] = NBT::unboxValue($tag);
 	}
 
 	/**
@@ -257,7 +257,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 			if(count($this->value) === 0){
 				$this->tagType = $type;
 			}else{
-				throw new \TypeError("Invalid tag of type " . get_class($tag) . " assigned to ListTag, expected " . get_class($this->value[0]));
+				throw new \TypeError("Invalid tag of type " . get_class($tag) . " assigned to ListTag, expected " . NBT::getClass($this->tagType));
 			}
 		}
 	}
@@ -267,6 +267,7 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 		$tagType = $reader->readByte();
 		$size = $reader->readInt();
 
+		$result = new self([], $tagType);
 		if($size > 0){
 			if($tagType === NBT::TAG_End){
 				throw new NbtDataException("Unexpected non-empty list of TAG_End");
@@ -274,31 +275,33 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 
 			$tracker->protectDepth(static function() use($size, $tagType, $reader, $tracker, &$value) : void{
 				for($i = 0; $i < $size; ++$i){
-					$value[] = NBT::createTag($tagType, $reader, $tracker);
+					$value[] = NBT::readValue($tagType, $reader, $tracker);
 				}
 			});
+			//set this directly, so we don't need to construct objects and do a bunch of useless type checks
+			$result->value = $value;
 		}
-		return new self($value, $tagType);
+		return $result;
 	}
 
 	public function write(NbtStreamWriter $writer) : void{
 		$writer->writeByte($this->tagType);
 		$writer->writeInt(count($this->value));
 		foreach($this->value as $tag){
-			$tag->write($writer);
+			NBT::writeValue($this->tagType, $tag, $writer);
 		}
 	}
 
 	protected function stringifyValue(int $indentation) : string{
 		$str = "{\n";
-		foreach($this->value as $tag){
+		foreach($this->getValue() as $tag){
 			$str .= str_repeat("  ", $indentation + 1) . $tag->toString($indentation + 1) . "\n";
 		}
 		return $str . str_repeat("  ", $indentation) . "}";
 	}
 
 	public function __clone(){
-		$this->value = array_map(fn(Tag $t) => $t->safeClone(), $this->value);
+		$this->value = array_map(fn(mixed $t) => $t instanceof Tag ? $t->safeClone() : $t, $this->value);
 	}
 
 	protected function makeCopy(){
@@ -310,16 +313,19 @@ final class ListTag extends Tag implements \Countable, \IteratorAggregate{
 	 * @phpstan-return \Generator<int, Tag, void, void>
 	 */
 	public function getIterator() : \Generator{
-		yield from $this->value;
+		foreach($this->value as $v){
+			yield NBT::boxValue($this->tagType, $v);
+		}
 	}
 
 	public function equals(Tag $that) : bool{
-		if(!($that instanceof $this) or count($this->value) !== count($that->value)){
+		if(!($that instanceof $this) || $this->tagType !== $that->tagType || count($this->value) !== count($that->value)){
 			return false;
 		}
 
 		foreach($this->value as $k => $v){
-			if(!$v->equals($that->value[$k])){
+			$thatV = $that->value[$k];
+			if($v !== $thatV && (!$v instanceof Tag || !$thatV instanceof Tag || !$v->equals($thatV))){
 				return false;
 			}
 		}

--- a/src/tag/LongTag.php
+++ b/src/tag/LongTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 
 final class LongTag extends ImmutableTag{
 	use IntegerishTagTrait;
@@ -42,13 +40,5 @@ final class LongTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_Long;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readLong());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeLong($this->value);
 	}
 }

--- a/src/tag/ShortTag.php
+++ b/src/tag/ShortTag.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 
 final class ShortTag extends ImmutableTag{
 	use IntegerishTagTrait;
@@ -40,13 +38,5 @@ final class ShortTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_Short;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readSignedShort());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeShort($this->value);
 	}
 }

--- a/src/tag/StringTag.php
+++ b/src/tag/StringTag.php
@@ -25,8 +25,6 @@ namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\InvalidTagValueException;
 use pocketmine\nbt\NBT;
-use pocketmine\nbt\NbtStreamReader;
-use pocketmine\nbt\NbtStreamWriter;
 use function func_num_args;
 use function strlen;
 
@@ -48,14 +46,6 @@ final class StringTag extends ImmutableTag{
 
 	public function getType() : int{
 		return NBT::TAG_String;
-	}
-
-	public static function read(NbtStreamReader $reader) : self{
-		return new self($reader->readString());
-	}
-
-	public function write(NbtStreamWriter $writer) : void{
-		$writer->writeString($this->value);
 	}
 
 	public function getValue() : string{

--- a/src/tag/Tag.php
+++ b/src/tag/Tag.php
@@ -23,8 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\nbt\tag;
 
-use pocketmine\nbt\NbtStreamWriter;
-
 abstract class Tag{
 
 	/**
@@ -37,8 +35,6 @@ abstract class Tag{
 	abstract public function getValue();
 
 	abstract public function getType() : int;
-
-	abstract public function write(NbtStreamWriter $writer) : void;
 
 	public function __toString(){
 		return $this->toString();

--- a/tests/phpstan/configs/phpstan-bugs.neon
+++ b/tests/phpstan/configs/phpstan-bugs.neon
@@ -13,7 +13,7 @@ parameters:
 			path: ../../../src/tag/IntArrayTag.php
 
 		-
-			message: '#^Property pocketmine\\nbt\\tag\\ListTag\:\:\$value \(list\<pocketmine\\nbt\\tag\\Tag\>\) does not accept non\-empty\-array\<int\<0, max\>, pocketmine\\nbt\\tag\\Tag\>\.$#'
+			message: '#^Property pocketmine\\nbt\\tag\\ListTag\:\:\$value \(list\<mixed\>\) does not accept non\-empty\-array\<int\<0, max\>, mixed\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: ../../../src/tag/ListTag.php

--- a/tests/phpunit/tag/CompoundTagTest.php
+++ b/tests/phpunit/tag/CompoundTagTest.php
@@ -67,11 +67,7 @@ class CompoundTagTest extends TestCase{
 		self::assertEquals($tag->getCount(), $tag2->getCount());
 
 		foreach($tag2 as $name => $child){
-			if($child instanceof ImmutableTag){
-				self::assertSame($child, $tag->getTag($name));
-			}else{
-				self::assertNotSame($child, $tag->getTag($name));
-			}
+			self::assertNotSame($child, $tag->getTag($name));
 		}
 	}
 

--- a/tests/phpunit/tag/ListTagTest.php
+++ b/tests/phpunit/tag/ListTagTest.php
@@ -83,11 +83,7 @@ class ListTagTest extends TestCase{
 		self::assertEquals($tag->getCount(), $tag2->getCount());
 
 		foreach($tag2 as $index => $child){
-			if($child instanceof ImmutableTag){
-				self::assertSame($child, $tag->get($index));
-			}else{
-				self::assertNotSame($child, $tag->get($index));
-			}
+			self::assertNotSame($child, $tag->get($index));
 		}
 	}
 


### PR DESCRIPTION
This PR implements #126.

The memory usage improvement is very slim according to initial tests - sadly the gains from not allocating the simple tag objects are negated by the losses from having a separate `valueTypes` array in `CompoundTag`.
Write performance is also marginally worse because of the extra array lookup in `CompoundTag->valueTypes`.

However, the performance of decoding is improved by about 10%, and equals() is more than 2x faster.

This architecture would favour implementing NBT as a PHP extension, since we'd be able to do considerably more optimizations at the native level than we can here.